### PR TITLE
Use environment variables for Supabase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ npm run dev
 - Click on "New codespace" to launch a new Codespace environment.
 - Edit files directly within the Codespace and commit and push your changes once you're done.
 
+## Environment variables
+
+Create a `.env` file in the project root (or use your hosting provider's settings) with the following variables:
+
+- `VITE_SUPABASE_URL` – URL of your Supabase instance used by the frontend
+- `VITE_SUPABASE_ANON_KEY` – public anon key for the frontend client
+- `SUPABASE_URL` – same Supabase URL for edge functions
+- `SUPABASE_ANON_KEY` – key used by edge functions
+
 ## What technologies are used for this project?
 
 This project is built with:

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://bmemdtbflrmdymxqpqhs.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJtZW1kdGJmbHJtZHlteHFwcWhzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk5MjUzNTIsImV4cCI6MjA2NTUwMTM1Mn0.fs1wAnmkGCGD7tbMpqot7sqFqYpLYuDzwCiYT32USTY";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/supabase/functions/generate-ai-blogpost/index.ts
+++ b/supabase/functions/generate-ai-blogpost/index.ts
@@ -27,9 +27,9 @@ serve(async (req) => {
 
   // --- Supabase client initialisieren
   const { createClient } = await import("npm:@supabase/supabase-js");
-  const SUPABASE_URL = "https://bmemdtbflrmdymxqpqhs.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJtZW1kdGJmbHJtZHlteHFwcWhzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk5MjUzNTIsImV4cCI6MjA2NTUwMTM1Mn0.fs1wAnmkGCGD7tbMpqot7sqFqYpLYuDzwCiYT32USTY";
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+  const SUPABASE_KEY = Deno.env.get("SUPABASE_ANON_KEY");
+  const supabase = createClient(SUPABASE_URL!, SUPABASE_KEY!);
 
   try {
     // 1. Kategorie bestimmen

--- a/supabase/functions/generate-blog-content/index.ts
+++ b/supabase/functions/generate-blog-content/index.ts
@@ -70,9 +70,9 @@ serve(async (req) => {
   }
 
   const { createClient } = await import("npm:@supabase/supabase-js");
-  const SUPABASE_URL = "https://bmemdtbflrmdymxqpqhs.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJtZW1kdGJmbHJtZHlteHFwcWhzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk5MjUzNTIsImV4cCI6MjA2NTUwMTM1Mn0.fs1wAnmkGCGD7tbMpqot7sqFqYpLYuDzwCiYT32USTY";
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+  const SUPABASE_KEY = Deno.env.get("SUPABASE_ANON_KEY");
+  const supabase = createClient(SUPABASE_URL!, SUPABASE_KEY!);
 
   try {
     const { topic, categorySlug, articleLength, autoPublish, imageUrl } = await req.json();

--- a/supabase/functions/sitemap/index.ts
+++ b/supabase/functions/sitemap/index.ts
@@ -8,10 +8,8 @@ const corsHeaders = {
   "Content-Type": "application/xml; charset=utf-8",
 };
 
-// IMPORTANT: These are placeholders and should be replaced by environment variables
-// in a real-world scenario for better security and configuration management.
-const SUPABASE_URL = "https://bmemdtbflrmdymxqpqhs.supabase.co";
-const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJtZW1kdGJmbHJtZHlteHFwcWhzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk5MjUzNTIsImV4cCI6MjA2NTUwMTM1Mn0.fs1wAnmkGCGD7tbMpqot7sqFqYpLYuDzwCiYT32USTY";
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const SUPABASE_KEY = Deno.env.get("SUPABASE_ANON_KEY");
 
 serve(async (_req) => {
   if (_req.method === "OPTIONS") {
@@ -19,7 +17,7 @@ serve(async (_req) => {
   }
 
   try {
-    const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+    const supabase = createClient(SUPABASE_URL!, SUPABASE_KEY!);
     const domain = "https://sanieren-sparen.de";
 
     // Static pages from App.tsx


### PR DESCRIPTION
## Summary
- remove hardcoded Supabase credentials
- load configuration from environment variables
- document required environment variables

## Testing
- `npm run lint` *(fails: 29 errors, 13 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684ec4e2430883208702811198d44d07