### PR TITLE
Fix duplicate header & footer

### DIFF
--- a/src/components/blog/post/BlogPostNotFound.tsx
+++ b/src/components/blog/post/BlogPostNotFound.tsx
@@ -1,19 +1,15 @@
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import { Link } from 'react-router-dom';
 
 const BlogPostNotFound = () => {
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <div className="max-w-4xl mx-auto px-4 py-16 text-center">
         <h1 className="text-2xl font-bold text-gray-900 mb-4">Artikel nicht gefunden</h1>
         <Link to="/blog" className="text-green-600 hover:text-green-700">
           ← Zurück zum Blog
         </Link>
       </div>
-      <Footer />
     </div>
   );
 };

--- a/src/components/blog/post/BlogPostSkeleton.tsx
+++ b/src/components/blog/post/BlogPostSkeleton.tsx
@@ -1,11 +1,8 @@
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 
 const BlogPostSkeleton = () => {
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <div className="max-w-4xl mx-auto px-4 py-16 text-center">
         <div className="animate-pulse">
           <div className="h-8 bg-gray-300 rounded mb-4"></div>
@@ -13,7 +10,6 @@ const BlogPostSkeleton = () => {
           <div className="h-4 bg-gray-300 rounded"></div>
         </div>
       </div>
-      <Footer />
     </div>
   );
 };

--- a/src/components/category/CategoryNotFound.tsx
+++ b/src/components/category/CategoryNotFound.tsx
@@ -1,15 +1,11 @@
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 
 const CategoryNotFound = () => (
     <div className="min-h-screen bg-gray-50">
-        <Header />
         <div className="max-w-7xl mx-auto px-4 py-8">
             <h1 className="text-2xl font-bold text-gray-900">Kategorie nicht gefunden</h1>
             <p className="text-gray-600 mt-2">Die von Ihnen gesuchte Kategorie existiert nicht oder wurde verschoben.</p>
         </div>
-        <Footer />
     </div>
 );
 

--- a/src/components/category/CategoryPageSkeleton.tsx
+++ b/src/components/category/CategoryPageSkeleton.tsx
@@ -1,11 +1,8 @@
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import { Skeleton } from '@/components/ui/skeleton';
 
 const CategoryPageSkeleton = () => (
   <div className="min-h-screen bg-gray-50">
-    <Header />
     <div className="max-w-7xl mx-auto px-4 py-8">
       <Skeleton className="h-8 w-1/4 mb-6" />
       <Skeleton className="h-16 w-1/2 mb-8" />
@@ -23,7 +20,6 @@ const CategoryPageSkeleton = () => (
         </div>
       </div>
     </div>
-    <Footer />
   </div>
 );
 

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,7 +1,5 @@
 
 import { useState } from 'react';
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import TopicFilter from '@/components/blog/TopicFilter';
 import { siteConfig } from '@/config/site.config';
 import { useBlogPosts } from '@/hooks/useBlogPosts';
@@ -37,7 +35,6 @@ const Blog = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       
       <div className="max-w-7xl mx-auto px-4 py-8">
         <BlogHero />
@@ -67,7 +64,6 @@ const Blog = () => {
         </div>
       </div>
 
-      <Footer />
     </div>
   );
 };

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -1,6 +1,4 @@
 import { useParams } from 'react-router-dom';
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import CategoryBenefits from '@/components/category/CategoryBenefits';
 import CategoryArticleSearch from "@/components/category/CategoryArticleSearch";
 import React, { useState, useMemo } from "react";
@@ -64,7 +62,6 @@ const CategoryPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       
       <div className="max-w-7xl mx-auto px-4 py-8">
         <CategoryHero category={currentTopic} />
@@ -96,7 +93,6 @@ const CategoryPage = () => {
         </div>
       </div>
 
-      <Footer />
     </div>
   );
 };

--- a/src/pages/DaemmungsrechnerPage.tsx
+++ b/src/pages/DaemmungsrechnerPage.tsx
@@ -1,6 +1,4 @@
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import InsulationCalculator from '@/components/calculators/InsulationCalculator';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Link } from 'react-router-dom';
@@ -9,7 +7,6 @@ import InsulationManufacturers from '@/components/manufacturers/InsulationManufa
 const DaemmungsrechnerPage = () => {
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main>
         <div className="max-w-3xl mx-auto px-4 py-8">
           <h1 className="text-3xl font-bold text-gray-900 mb-4 animate-fade-in">
@@ -40,7 +37,6 @@ const DaemmungsrechnerPage = () => {
           <InsulationManufacturers />
         </div>
       </main>
-      <Footer />
     </div>
   );
 };

--- a/src/pages/Datenschutz.tsx
+++ b/src/pages/Datenschutz.tsx
@@ -1,12 +1,9 @@
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import AdSlot from '@/components/ui/AdSlot';
 
 const Datenschutz = () => {
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       
       <div className="max-w-4xl mx-auto px-4 py-12">
         <AdSlot position="banner" className="w-full mb-8" />
@@ -79,7 +76,6 @@ const Datenschutz = () => {
         </div>
       </div>
 
-      <Footer />
     </div>
   );
 };

--- a/src/pages/FensterTuerenPage.tsx
+++ b/src/pages/FensterTuerenPage.tsx
@@ -1,6 +1,4 @@
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import { siteConfig } from '@/config/site.config';
 import TaggedBlogPostsGrid from '@/components/blog/TaggedBlogPostsGrid';
 import FensterTuerenHero from '@/components/fenster-tueren/FensterTuerenHero';
@@ -12,7 +10,6 @@ const FensterTuerenPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="py-12">
         <div className="max-w-4xl mx-auto px-4">
           <FensterTuerenHero topic={topic} />
@@ -23,7 +20,6 @@ const FensterTuerenPage = () => {
           <TaggedBlogPostsGrid tag="Fenster" title="Weitere spannende Artikel zu Fenster & Türen:" />
         </div>
       </main>
-      <Footer />
     </div>
   );
 };

--- a/src/pages/FoerdermittelPage.tsx
+++ b/src/pages/FoerdermittelPage.tsx
@@ -1,5 +1,3 @@
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import { siteConfig } from '@/config/site.config';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Link } from 'react-router-dom';
@@ -12,7 +10,6 @@ const FoerdermittelPage = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-yellow-50 to-green-50 dark:from-gray-900 dark:to-gray-800">
-      <Header />
       <main className="pb-12">
         <div className="max-w-4xl mx-auto px-4">
           {/* Einleitung */}
@@ -125,7 +122,6 @@ const FoerdermittelPage = () => {
           </Card>
         </div>
       </main>
-      <Footer />
     </div>
   );
 };

--- a/src/pages/HeizkostenrechnerPage.tsx
+++ b/src/pages/HeizkostenrechnerPage.tsx
@@ -1,16 +1,12 @@
 
 import ModernizationSavingsCalculator from '@/components/calculators/ModernizationSavingsCalculator';
-import Footer from '@/components/layout/Footer';
-import Header from '@/components/layout/Header';
 
 const HeizkostenrechnerPage = () => {
   return (
     <div className="flex flex-col min-h-screen">
-      <Header />
       <main className="flex-grow container mx-auto px-4 py-8">
         <ModernizationSavingsCalculator />
       </main>
-      <Footer />
     </div>
   );
 };

--- a/src/pages/Impressum.tsx
+++ b/src/pages/Impressum.tsx
@@ -1,12 +1,9 @@
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import AdSlot from '@/components/ui/AdSlot';
 
 const Impressum = () => {
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       
       <div className="max-w-4xl mx-auto px-4 py-12">
         <AdSlot position="banner" className="w-full mb-8" />
@@ -87,7 +84,6 @@ const Impressum = () => {
         </div>
       </div>
 
-      <Footer />
     </div>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,4 @@
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import { useBlogPosts } from '@/hooks/useBlogPosts';
 import { useBlogCategories } from '@/hooks/useBlogCategories';
 import HeroSection from '@/components/home/HeroSection';
@@ -21,7 +19,6 @@ const Index = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 via-blue-50 to-white">
-      <Header />
       
       <main>
         <HeroSection />
@@ -117,7 +114,6 @@ const Index = () => {
         
         <NewsletterSection />
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/Kontakt.tsx
+++ b/src/pages/Kontakt.tsx
@@ -1,14 +1,11 @@
 
 import { Mail, Phone, MapPin, Clock } from 'lucide-react';
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import AdSlot from '@/components/ui/AdSlot';
 import { siteConfig } from '@/config/site.config';
 
 const Kontakt = () => {
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       
       <div className="max-w-4xl mx-auto px-4 py-12">
         {/* Header Banner Ad */}
@@ -137,7 +134,6 @@ const Kontakt = () => {
         </div>
       </div>
 
-      <Footer />
     </div>
   );
 };

--- a/src/pages/SmartHomePage.tsx
+++ b/src/pages/SmartHomePage.tsx
@@ -1,5 +1,3 @@
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import { siteConfig } from '@/config/site.config';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -297,7 +295,6 @@ const SmartHomePage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="py-12">
         <div className="max-w-6xl mx-auto px-2 sm:px-4">
           <h1 className="text-4xl font-bold mb-4">Smart Home: Bereiche & Möglichkeiten</h1>
@@ -354,7 +351,6 @@ const SmartHomePage = () => {
           </p>
         </div>
       </main>
-      <Footer />
     </div>
   );
 };

--- a/src/pages/SolarenergiePage.tsx
+++ b/src/pages/SolarenergiePage.tsx
@@ -1,5 +1,3 @@
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import { siteConfig } from '@/config/site.config';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -14,7 +12,6 @@ const SolarenergiePage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <Header />
       <main className="py-12 md:py-16">
         <div className="container max-w-5xl mx-auto px-4 space-y-12">
           
@@ -248,7 +245,6 @@ const SolarenergiePage = () => {
 
         </div>
       </main>
-      <Footer />
     </div>
   );
 };

--- a/src/pages/Wissenswertes.tsx
+++ b/src/pages/Wissenswertes.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { ExternalLink, Mail, Instagram, Facebook } from 'lucide-react';
-import Footer from '@/components/layout/Footer';
 import { siteConfig } from '@/config/site.config';
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import InsulationManufacturers from '@/components/manufacturers/InsulationManufacturers';
@@ -198,7 +197,6 @@ const Wissenswertes = () => {
         <InsulationManufacturers />
       </main>
 
-      <Footer />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove page-specific Header/Footer so they render only once via `App`
- clean up fallback components for consistency

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ecbb2a218832087c171ae1594c95d