### PR TITLE
Add dashboard pages and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import NotFound from "./pages/NotFound";
 import AuthPage from "./pages/AuthPage";
 import AdminDashboard from "./pages/AdminDashboard";
 import AdminBlogPosts from "./pages/AdminBlogPosts";
+import UserDashboard from "./pages/UserDashboard";
 
 const queryClient = new QueryClient();
 
@@ -64,6 +65,7 @@ function App() {
                   <Route path="/impressum" element={<Impressum />} />
                   <Route path="/datenschutz" element={<Datenschutz />} />
                   <Route path="/auth" element={<AuthPage />} />
+                  <Route path="/dashboard" element={<UserDashboard />} />
                   <Route path="/admin" element={<AdminDashboard />} />
                   <Route path="/admin/blog" element={<AdminBlogPosts />} />
                   <Route path="/suche" element={<SearchPage />} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -141,6 +141,13 @@ const Header = () => {
                     </Link>
                   </SheetClose>
                 )}
+                {session && profile?.role !== 'admin' && (
+                  <SheetClose asChild>
+                    <Link to="/dashboard" className="font-semibold text-lg">
+                      Dashboard
+                    </Link>
+                  </SheetClose>
+                )}
                 {!session && (
                   <SheetClose asChild>
                     <Link to="/auth" className="font-semibold text-lg">
@@ -194,6 +201,14 @@ const Header = () => {
                   className={cn(navigationMenuTriggerStyle(), 'bg-transparent hover:text-blue-600 font-semibold')}
                 >
                   Admin
+                </Link>
+              )}
+              {session && profile?.role !== 'admin' && (
+                <Link
+                  to="/dashboard"
+                  className={cn(navigationMenuTriggerStyle(), 'bg-transparent hover:text-blue-600 font-semibold')}
+                >
+                  Dashboard
                 </Link>
               )}
               {!session && (

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -19,19 +19,32 @@ const AuthPage = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    const redirectAfterLogin = async (s: any) => {
+      const { data } = await supabase
+        .from("profiles")
+        .select("role")
+        .eq("id", s.user.id)
+        .maybeSingle();
+      if (data?.role === "admin") {
+        navigate("/admin", { replace: true });
+      } else {
+        navigate("/dashboard", { replace: true });
+      }
+    };
+
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session);
       if (session) {
-        navigate("/admin", { replace: true });
+        redirectAfterLogin(session);
       }
     });
 
-    supabase.auth.getSession().then(({ data: { session } }) => {
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
       setSession(session);
       if (session) {
-        navigate("/admin", { replace: true });
+        redirectAfterLogin(session);
       }
     });
 
@@ -63,7 +76,7 @@ const AuthPage = () => {
         return;
       }
 
-      const redirectUrl = `${window.location.origin}/admin`;
+      const redirectUrl = `${window.location.origin}/dashboard`;
       const { error } = await supabase.auth.signUp({
         email,
         password,

--- a/src/pages/UserDashboard.tsx
+++ b/src/pages/UserDashboard.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { useNavigate } from "react-router-dom";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+
+const UserDashboard = () => {
+  const [session, setSession] = useState<any>(null);
+  const [profile, setProfile] = useState<any>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const init = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        navigate("/auth", { replace: true });
+        return;
+      }
+      setSession(session);
+      const { data } = await supabase
+        .from("profiles")
+        .select("username, role")
+        .eq("id", session.user.id)
+        .maybeSingle();
+      setProfile(data);
+    };
+    init();
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+      if (!session) {
+        toast.info("Sie wurden ausgeloggt.");
+        navigate("/auth", { replace: true });
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, [navigate]);
+
+  const onLogout = async () => {
+    await supabase.auth.signOut();
+    navigate("/", { replace: true });
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 to-blue-50">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Dashboard</CardTitle>
+          <div className="text-gray-500 text-sm">
+            Willkommen, {profile?.username || session?.user?.email}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Button className="w-full" variant="secondary" onClick={onLogout}>
+            Logout
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default UserDashboard;


### PR DESCRIPTION
## Summary
- add a simple user dashboard
- link dashboard routes in header
- redirect from login to the appropriate dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684fedece93483209e29986fa544f2bb