### PR TITLE
Add nested admin routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import AuthPage from "./pages/AuthPage";
 import AdminDashboard from "./pages/AdminDashboard";
 import AdminBlogPosts from "./pages/AdminBlogPosts";
 import UserDashboard from "./pages/UserDashboard";
+import AdminLayout from "./components/layout/AdminLayout";
 
 const queryClient = new QueryClient();
 
@@ -66,8 +67,11 @@ function App() {
                   <Route path="/datenschutz" element={<Datenschutz />} />
                   <Route path="/auth" element={<AuthPage />} />
                   <Route path="/dashboard" element={<UserDashboard />} />
-                  <Route path="/admin" element={<AdminDashboard />} />
-                  <Route path="/admin/blog" element={<AdminBlogPosts />} />
+                  <Route path="/admin" element={<AdminLayout />}>
+                    <Route index element={<AdminDashboard />} />
+                    <Route path="dashboard" element={<AdminDashboard />} />
+                    <Route path="blog" element={<AdminBlogPosts />} />
+                  </Route>
                   <Route path="/suche" element={<SearchPage />} />
                   <Route path="*" element={<NotFound />} />
                 </Routes>

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router-dom";
+
+const AdminLayout = () => {
+  return (
+    <div className="p-4">
+      <Outlet />
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -135,11 +135,18 @@ const Header = () => {
                   )
                 ))}
                 {profile?.role === 'admin' && (
-                  <SheetClose asChild>
-                    <Link to="/admin" className="font-semibold text-lg">
-                      Admin
-                    </Link>
-                  </SheetClose>
+                  <div className="space-y-2">
+                    <SheetClose asChild>
+                      <Link to="/admin" className="font-semibold text-lg">
+                        Admin Dashboard
+                      </Link>
+                    </SheetClose>
+                    <SheetClose asChild>
+                      <Link to="/admin/blog" className="font-semibold text-lg">
+                        Blog-Verwaltung
+                      </Link>
+                    </SheetClose>
+                  </div>
                 )}
                 {session && profile?.role !== 'admin' && (
                   <SheetClose asChild>
@@ -196,12 +203,20 @@ const Header = () => {
 
             <div className="flex items-center space-x-2 ml-4">
               {profile?.role === 'admin' && (
-                <Link
-                  to="/admin"
-                  className={cn(navigationMenuTriggerStyle(), 'bg-transparent hover:text-blue-600 font-semibold')}
-                >
-                  Admin
-                </Link>
+                <>
+                  <Link
+                    to="/admin"
+                    className={cn(navigationMenuTriggerStyle(), 'bg-transparent hover:text-blue-600 font-semibold')}
+                  >
+                    Admin Dashboard
+                  </Link>
+                  <Link
+                    to="/admin/blog"
+                    className={cn(navigationMenuTriggerStyle(), 'bg-transparent hover:text-blue-600 font-semibold')}
+                  >
+                    Blog-Verwaltung
+                  </Link>
+                </>
               )}
               {session && profile?.role !== 'admin' && (
                 <Link


### PR DESCRIPTION
## Summary
- add a simple `AdminLayout` component
- nest all admin pages under `/admin/*`
- add links for Admin Dashboard and Blog management in header navigation

## Testing
- `npm run lint` *(fails: Unexpected any usage)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ff03940248320b15d32e2ac1a4dc6