### PR TITLE
Add admin generator route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import NotFound from "./pages/NotFound";
 import AuthPage from "./pages/AuthPage";
 import AdminDashboard from "./pages/AdminDashboard";
 import AdminBlogPosts from "./pages/AdminBlogPosts";
+import AdminBlogGenerator from "./pages/AdminBlogGenerator";
 import UserDashboard from "./pages/UserDashboard";
 import AdminLayout from "./components/layout/AdminLayout";
 
@@ -71,6 +72,7 @@ function App() {
                     <Route index element={<AdminDashboard />} />
                     <Route path="dashboard" element={<AdminDashboard />} />
                     <Route path="blog" element={<AdminBlogPosts />} />
+                    <Route path="blog/generator" element={<AdminBlogGenerator />} />
                   </Route>
                   <Route path="/suche" element={<SearchPage />} />
                   <Route path="*" element={<NotFound />} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -146,6 +146,11 @@ const Header = () => {
                         Blog-Verwaltung
                       </Link>
                     </SheetClose>
+                    <SheetClose asChild>
+                      <Link to="/admin/blog/generator" className="font-semibold text-lg">
+                        Blog Generator
+                      </Link>
+                    </SheetClose>
                   </div>
                 )}
                 {session && profile?.role !== 'admin' && (
@@ -215,6 +220,12 @@ const Header = () => {
                     className={cn(navigationMenuTriggerStyle(), 'bg-transparent hover:text-blue-600 font-semibold')}
                   >
                     Blog-Verwaltung
+                  </Link>
+                  <Link
+                    to="/admin/blog/generator"
+                    className={cn(navigationMenuTriggerStyle(), 'bg-transparent hover:text-blue-600 font-semibold')}
+                  >
+                    Blog Generator
                   </Link>
                 </>
               )}

--- a/src/pages/AdminBlogGenerator.tsx
+++ b/src/pages/AdminBlogGenerator.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { toast } from "sonner";
+import BlogContentGenerator from "@/components/admin/BlogContentGenerator";
+
+const AdminBlogGenerator = () => {
+  const [profile, setProfile] = useState<any>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const init = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (!session) {
+        navigate("/auth", { replace: true });
+        return;
+      }
+
+      const { data: p, error } = await supabase
+        .from("profiles")
+        .select("*")
+        .eq("id", session.user.id)
+        .maybeSingle();
+
+      if (error || !p || p.role !== "admin") {
+        toast.error("Zugriff verweigert", {
+          description: "Sie sind kein Administrator.",
+        });
+        navigate("/", { replace: true });
+        return;
+      }
+
+      setProfile(p);
+    };
+
+    init();
+  }, [navigate]);
+
+  if (!profile) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-white">
+        <span className="text-xl text-gray-500 animate-pulse">Überprüfe Berechtigung...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container max-w-2xl mx-auto py-10 px-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Automatische Blogerstellung</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BlogContentGenerator onArticleCreated={() => {}} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default AdminBlogGenerator;

--- a/src/pages/UserDashboard.tsx
+++ b/src/pages/UserDashboard.tsx
@@ -54,6 +54,9 @@ const UserDashboard = () => {
           </div>
         </CardHeader>
         <CardContent>
+          {profile?.role === 'admin' && (
+            <Button className="w-full mb-4" onClick={() => navigate('/admin')}>Admin Dashboard</Button>
+          )}
           <Button className="w-full" variant="secondary" onClick={onLogout}>
             Logout
           </Button>


### PR DESCRIPTION
## Summary
- create `AdminBlogGenerator` page for automated blog creation
- expose generator route under `/admin/blog/generator`
- link generator in header when user has admin role
- show Admin Dashboard link on user dashboard when the user is an admin

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6858198dcb7083209d9a963b13bed33d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Blog Generator" page accessible to admins at /admin/blog/generator.
  - Added a "Blog Generator" link to the admin navigation in both desktop and mobile views.
  - Displayed an "Admin Dashboard" button in the user dashboard for admin users.

- **Bug Fixes**
  - Improved authentication and authorization checks for accessing admin-only pages, with appropriate redirects and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->