### PR TITLE
Load AdSense after consent

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,6 @@
     <!-- Google Analytics 4 -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
 
-    <!-- Google AdSense - Auto Ads (korrekte Implementierung) -->
-    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4326654077043920" crossorigin="anonymous" data-adbreak-test="on"></script>
 
     <!-- Enhanced Structured Data -->
     <script type="application/ld+json">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,10 +40,12 @@ import AdminBlogPosts from "./pages/AdminBlogPosts";
 import AdminBlogGenerator from "./pages/AdminBlogGenerator";
 import UserDashboard from "./pages/UserDashboard";
 import AdminLayout from "./components/layout/AdminLayout";
+import { useAdsense } from "@/hooks/useAdsense";
 
 const queryClient = new QueryClient();
 
 function App() {
+  useAdsense();
   return (
     <QueryClientProvider client={queryClient}>
       <HelmetProvider>

--- a/src/hooks/useAdsense.ts
+++ b/src/hooks/useAdsense.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { siteConfig } from '@/config/site.config';
+
+export const useAdsense = () => {
+  useEffect(() => {
+    if (!siteConfig.adsEnabled || !siteConfig.googleServices.adsense.enabled) {
+      return;
+    }
+
+    const loadScript = () => {
+      if (typeof window === 'undefined' || (window as any).adSenseInitialized) {
+        return;
+      }
+      const script = document.createElement('script');
+      script.async = true;
+      script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${siteConfig.googleServices.adsense.publisherId}`;
+      script.crossOrigin = 'anonymous';
+      const adtest = siteConfig.googleServices.adsense.config.adtest;
+      if (adtest) {
+        script.setAttribute('data-adbreak-test', adtest);
+      }
+      document.head.appendChild(script);
+      (window as any).adSenseInitialized = true;
+    };
+
+    try {
+      const consentStr = localStorage.getItem('cookie-consent');
+      const consent = consentStr ? JSON.parse(consentStr) : null;
+      if (consent?.advertising) {
+        loadScript();
+      }
+    } catch (err) {
+      console.error('AdSense initialization failed', err);
+    }
+  }, []);
+};

--- a/src/hooks/useAdsense.ts
+++ b/src/hooks/useAdsense.ts
@@ -25,12 +25,18 @@ export const useAdsense = () => {
 
     try {
       const consentStr = localStorage.getItem('cookie-consent');
-      const consent = consentStr ? JSON.parse(consentStr) : null;
-      if (consent?.advertising) {
+      if (!consentStr) {
+        console.log('No consent data found, skipping AdSense loading');
+        return;
+      }
+      const consent = JSON.parse(consentStr);
+      if (consent && typeof consent === 'object' && consent.advertising === true) {
         loadScript();
+      } else {
+        console.log('Advertising consent not granted, skipping AdSense loading');
       }
     } catch (err) {
-      console.error('AdSense initialization failed', err);
+      console.error('AdSense initialization failed - invalid consent data:', err);
     }
   }, []);
 };


### PR DESCRIPTION
## Summary
- add `useAdsense` hook that injects the Google AdSense script only when advertising consent is granted
- integrate the hook in `App.tsx`
- remove static AdSense script tag from `index.html`

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688604e9f9208320be224361ed20a10a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AdSense script is now loaded dynamically based on user consent and configuration settings, improving privacy and control over ad loading.

* **Chores**
  * Removed the static Google AdSense script from the HTML head section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->