### PR TITLE
Load AdSense after consent update

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,6 @@
     <!-- Google Analytics 4 -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
 
-    <!-- Google AdSense - Auto Ads (korrekte Implementierung) -->
-    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4326654077043920" crossorigin="anonymous" data-adbreak-test="on"></script>
 
     <!-- Enhanced Structured Data -->
     <script type="application/ld+json">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,10 +40,12 @@ import AdminBlogPosts from "./pages/AdminBlogPosts";
 import AdminBlogGenerator from "./pages/AdminBlogGenerator";
 import UserDashboard from "./pages/UserDashboard";
 import AdminLayout from "./components/layout/AdminLayout";
+import { useAdsense } from "@/hooks/useAdsense";
 
 const queryClient = new QueryClient();
 
 function App() {
+  useAdsense();
   return (
     <QueryClientProvider client={queryClient}>
       <HelmetProvider>

--- a/src/components/ui/CookieConsent.tsx
+++ b/src/components/ui/CookieConsent.tsx
@@ -76,6 +76,7 @@ const CookieConsent = () => {
       
       localStorage.setItem('cookie-consent', JSON.stringify(consentData));
       updateGoogleConsent(analytics, advertising);
+      window.dispatchEvent(new Event('ads_consent_updated'));
       setShowConsent(false);
 
       // Tracking-Events für Consent

--- a/src/hooks/useAdsense.ts
+++ b/src/hooks/useAdsense.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+
+declare global {
+  interface Window {
+    adSenseInitialized?: boolean;
+  }
+}
+import { siteConfig } from '@/config/site.config';
+
+export const useAdsense = () => {
+  useEffect(() => {
+    if (!siteConfig.adsEnabled || !siteConfig.googleServices.adsense.enabled) {
+      return;
+    }
+
+    const loadScript = () => {
+      if (typeof window === 'undefined' || window.adSenseInitialized) {
+        return;
+      }
+      const script = document.createElement('script');
+      script.async = true;
+      script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${siteConfig.googleServices.adsense.publisherId}`;
+      script.crossOrigin = 'anonymous';
+      const adtest = siteConfig.googleServices.adsense.config.adtest;
+      if (adtest) {
+        script.setAttribute('data-adbreak-test', adtest);
+      }
+      document.head.appendChild(script);
+      window.adSenseInitialized = true;
+    };
+
+    const tryLoad = () => {
+      try {
+        const consentStr = localStorage.getItem('cookie-consent');
+        const consent = consentStr ? JSON.parse(consentStr) : null;
+        if (consent?.advertising) {
+          loadScript();
+        }
+      } catch (err) {
+        console.error('AdSense initialization failed', err);
+      }
+    };
+
+    window.addEventListener('ads_consent_updated', tryLoad);
+    tryLoad();
+    return () => {
+      window.removeEventListener('ads_consent_updated', tryLoad);
+    };
+  }, []);
+};


### PR DESCRIPTION
## Summary
- fire `ads_consent_updated` event when consent saved
- listen for the event in the `useAdsense` hook to load ads after consent changes

## Testing
- `npm run lint` *(fails: 33 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688604e9f9208320be224361ed20a10a