### PR TITLE
Add smart home savings details

### DIFF
--- a/src/components/calculators/ModernizationSavingsCalculator.tsx
+++ b/src/components/calculators/ModernizationSavingsCalculator.tsx
@@ -18,6 +18,7 @@ const ModernizationSavingsCalculator = () => {
     customPrices,
     selectedSmartSystems,
     estimateSmartInvestment,
+    getRecommendedSmartSystems,
     results,
     handleInputChange,
     setCalculationMode,
@@ -57,6 +58,7 @@ const ModernizationSavingsCalculator = () => {
               selectedSmartSystems={selectedSmartSystems}
               toggleSmartSystem={toggleSmartSystem}
               estimateSmartInvestment={estimateSmartInvestment}
+              recommendedSystems={getRecommendedSmartSystems()}
             />
           </div>
 

--- a/src/components/calculators/modernization/CalculatorResults.tsx
+++ b/src/components/calculators/modernization/CalculatorResults.tsx
@@ -22,6 +22,11 @@ const CalculatorResults = ({ results, investmentCosts }: CalculatorResultsProps)
               <p className="text-lg font-semibold text-gray-800">Jährliche Ersparnis</p>
               <p className="text-5xl font-bold text-green-600 my-1">{results.annualSavings.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' })}</p>
               <p className="text-lg font-semibold text-green-700">({results.savingsPercentage.toFixed(0)}% weniger Kosten)</p>
+              {results.smartHomeSavings > 0 && (
+                <p className="text-sm text-green-800 mt-1">
+                  Davon {results.smartHomeSavings.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' })} durch Smart Home
+                </p>
+              )}
             </div>
             <div className="text-center">
               {results.amortizationPeriod ? (
@@ -40,6 +45,9 @@ const CalculatorResults = ({ results, investmentCosts }: CalculatorResultsProps)
                   <p className="text-5xl font-bold text-blue-600 my-1">
                       {results.amortizationPeriod.toFixed(1)} <span className="text-3xl">Jahre</span>
                   </p>
+                  {results.amortizationWithoutSmart && (
+                    <p className="text-sm text-blue-700">Ohne Smart Home: {results.amortizationWithoutSmart.toFixed(1)} Jahre</p>
+                  )}
                 </>
               ) : parseFloat(investmentCosts) > 0 ? (
                 <>
@@ -55,6 +63,10 @@ const CalculatorResults = ({ results, investmentCosts }: CalculatorResultsProps)
           Geschätzte Smart-Home-Investition:{' '}
           {results.smartHomeInvestment.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' })}
         </p>
+        <p className="text-center text-sm text-gray-600">
+          Gesamte Investition inkl. Smart Home:{' '}
+          {results.totalInvestment.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' })}
+        </p>
 
         {/* CO2-Einsparung */}
         <div className="mt-8">
@@ -66,6 +78,11 @@ const CalculatorResults = ({ results, investmentCosts }: CalculatorResultsProps)
             </div>
           </div>
           <div className="text-xs text-gray-500 text-center mt-1">Durch Ihre Maßnahmen sinkt Ihr jährlicher Treibhausgas-Ausstoß deutlich.</div>
+          {results.smartHomeSavings > 0 && (
+            <p className="text-xs text-center text-green-700 mt-2">
+              Davon {results.co2SavingsSmart.toLocaleString('de-DE', { minimumFractionDigits: 0, maximumFractionDigits: 0 })} kg durch Smart Home Steuerung
+            </p>
+          )}
         </div>
         
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-start text-center mt-6 pt-6 border-t">

--- a/src/components/calculators/modernization/ModernizationPlanSection.tsx
+++ b/src/components/calculators/modernization/ModernizationPlanSection.tsx
@@ -1,4 +1,5 @@
 
+import { useState } from 'react';
 import { Home, Heater, Landmark, Info } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -6,6 +7,15 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { CalculatorInputs, HeatingType, InsulationQuality, SmartHomeSystem } from '@/hooks/useModernizationCalculator';
 import { Checkbox } from '@/components/ui/checkbox';
+
+const SMART_HOME_INFOS: Record<SmartHomeSystem, string> = {
+  thermostat: 'Intelligente Thermostate optimieren automatisch die Raumtemperatur.',
+  heizungssteuerung: 'Zentrale Steuerung der gesamten Heizungsanlage.',
+  sensoren: 'Erkennt offene Fenster und passt die Heizung an.',
+  energiemanagement: 'Optimiert Eigenverbrauch und Lastspitzen.',
+  wetterstation: 'Passt die Heizung an aktuelle Wetterdaten an.',
+  sprachsteuerung: 'Ermöglicht komfortable Sprachbefehle.',
+};
 
 interface ModernizationPlanSectionProps {
   inputs: CalculatorInputs;
@@ -15,9 +25,20 @@ interface ModernizationPlanSectionProps {
   selectedSmartSystems: SmartHomeSystem[];
   toggleSmartSystem: (system: SmartHomeSystem) => void;
   estimateSmartInvestment: () => number;
+  recommendedSystems: SmartHomeSystem[];
 }
 
-const ModernizationPlanSection = ({ inputs, handleInputChange, investmentCosts, setInvestmentCosts, selectedSmartSystems, toggleSmartSystem, estimateSmartInvestment }: ModernizationPlanSectionProps) => {
+const ModernizationPlanSection = ({
+  inputs,
+  handleInputChange,
+  investmentCosts,
+  setInvestmentCosts,
+  selectedSmartSystems,
+  toggleSmartSystem,
+  estimateSmartInvestment,
+  recommendedSystems,
+}: ModernizationPlanSectionProps) => {
+  const [showSmartOptions, setShowSmartOptions] = useState(false);
   return (
     <div className="space-y-4 p-4 border rounded-lg bg-white">
       <h3 className="font-bold text-lg text-gray-800">Geplante Modernisierung</h3>
@@ -58,30 +79,51 @@ const ModernizationPlanSection = ({ inputs, handleInputChange, investmentCosts, 
         </Select>
       </div>
       <div>
-        <Label className="text-sm font-semibold text-gray-700">Smart Home Systeme</Label>
-        <div className="grid grid-cols-2 gap-2 mt-2">
-          {[
-            { id: 'thermostat', label: 'Thermostate' },
-            { id: 'heizungssteuerung', label: 'Heizungssteuerung' },
-            { id: 'sensoren', label: 'Sensoren' },
-            { id: 'energiemanagement', label: 'Energie-Management' },
-            { id: 'wetterstation', label: 'Wetterstation' },
-            { id: 'sprachsteuerung', label: 'Sprachsteuerung' },
-          ].map((opt) => (
-            <label key={opt.id} className="flex items-center space-x-2 text-sm">
-              <Checkbox
-                id={opt.id}
-                checked={selectedSmartSystems.includes(opt.id as SmartHomeSystem)}
-                onCheckedChange={() => toggleSmartSystem(opt.id as SmartHomeSystem)}
-              />
-              <span>{opt.label}</span>
-            </label>
-          ))}
-        </div>
-        <p className="text-xs text-gray-500 mt-2">
-          Geschätzte Zusatzkosten:{' '}
-          {estimateSmartInvestment().toLocaleString('de-DE', { style: 'currency', currency: 'EUR' })}
-        </p>
+        <button
+          type="button"
+          onClick={() => setShowSmartOptions(!showSmartOptions)}
+          className="text-sm font-semibold text-gray-700 underline"
+        >
+          {showSmartOptions ? 'Smart Home Optionen verbergen' : 'Smart Home Optionen anzeigen'}
+        </button>
+        {showSmartOptions && (
+          <div className="mt-2">
+            <Label className="text-sm font-semibold text-gray-700">Smart Home Systeme</Label>
+            <div className="grid grid-cols-2 gap-2 mt-2">
+              {[
+                { id: 'thermostat', label: 'Thermostate' },
+                { id: 'heizungssteuerung', label: 'Heizungssteuerung' },
+                { id: 'sensoren', label: 'Sensoren' },
+                { id: 'energiemanagement', label: 'Energie-Management' },
+                { id: 'wetterstation', label: 'Wetterstation' },
+                { id: 'sprachsteuerung', label: 'Sprachsteuerung' },
+              ].map((opt) => (
+                <Tooltip key={opt.id}>
+                  <TooltipTrigger asChild>
+                    <label className="flex items-center space-x-2 text-sm">
+                      <Checkbox
+                        id={opt.id}
+                        checked={selectedSmartSystems.includes(opt.id as SmartHomeSystem)}
+                        onCheckedChange={() => toggleSmartSystem(opt.id as SmartHomeSystem)}
+                      />
+                      <span>{opt.label}</span>
+                    </label>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="max-w-xs text-sm">{SMART_HOME_INFOS[opt.id as SmartHomeSystem]}</p>
+                  </TooltipContent>
+                </Tooltip>
+              ))}
+            </div>
+            <p className="text-xs text-gray-500 mt-2">
+              Geschätzte Zusatzkosten:{' '}
+              {estimateSmartInvestment().toLocaleString('de-DE', { style: 'currency', currency: 'EUR' })}
+            </p>
+            {recommendedSystems.length > 0 && (
+              <p className="text-xs text-green-700 mt-1">Empfohlen: {recommendedSystems.join(', ')}</p>
+            )}
+          </div>
+        )}
       </div>
       <div className="pt-2">
         <Tooltip>


### PR DESCRIPTION
## Summary
- enhance modernization calculator with smart home metrics
- show smart home savings and CO₂ reduction in results
- add progressive smart home options with tooltips and recommendations

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other pre-existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b5f61146483209a49ce054d10e96d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed breakdowns for Smart Home-related savings, investments, and CO2 reductions in modernization calculator results.
  * Introduced a toggleable section for Smart Home system options, now enhanced with tooltips and descriptive information.
  * Display of recommended Smart Home systems based on user data.
* **Enhancements**
  * Results now show both total and Smart Home-specific amortization periods and savings for greater transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->