### PR TITLE
Expand German content for planning tools

### DIFF
--- a/src/components/wissenswertes/InteractiveTools.tsx
+++ b/src/components/wissenswertes/InteractiveTools.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Link } from 'react-router-dom';
 import { Calculator, PlaneTakeoff, Zap, TrendingUp, Calendar, MapPin } from 'lucide-react';
 
 const InteractiveTools = () => {
@@ -8,8 +9,8 @@ const InteractiveTools = () => {
       title: "Sanierungsplaner",
       description: "Schritt-für-Schritt Planung Ihres Renovierungsprojekts",
       icon: PlaneTakeoff,
-      comingSoon: true,
-      path: "/planer"
+      comingSoon: false,
+      path: "/projektplaner"
     },
     {
       title: "Förderrechner",
@@ -79,12 +80,13 @@ const InteractiveTools = () => {
               <CardDescription className="mb-4 text-base">
                 {tool.description}
               </CardDescription>
-              <Button 
-                className="w-full" 
+              <Button
+                className="w-full"
                 variant={tool.comingSoon ? "outline" : "default"}
                 disabled={tool.comingSoon}
+                asChild={!tool.comingSoon}
               >
-                {tool.comingSoon ? "Bald verfügbar" : "Tool starten"}
+                {tool.comingSoon ? "Bald verfügbar" : <Link to={tool.path}>Tool starten</Link>}
               </Button>
             </CardContent>
           </Card>

--- a/src/pages/BudgetplanPage.tsx
+++ b/src/pages/BudgetplanPage.tsx
@@ -1,15 +1,77 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Link } from "react-router-dom";
 
 const BudgetplanPage = () => {
   return (
-    <div className="container mx-auto py-10">
-      <Card>
+    <div className="container mx-auto py-10 space-y-8">
+      <Card className="animate-fade-in">
         <CardHeader>
-          <CardTitle>Budgetplan</CardTitle>
+          <CardTitle>Budgetplaner für Ihre Sanierung</CardTitle>
         </CardHeader>
-        <CardContent>
-          <p>Hier können Sie Ihr Budget für die Sanierung planen und Fördermittel im Auge behalten. Diese Funktion ist in Kürze verfügbar.</p>
+        <CardContent className="space-y-6 text-base leading-relaxed">
+          <p>
+            Ein durchdachter Budgetplan ist das finanzielle Rückgrat jeder Modernisierung.
+            Er hilft, Ausgaben realistisch einzuschätzen, Reserven einzuplanen und
+            die passende Förderung zu berücksichtigen. Mit unserem Budgetplaner behalten
+            Sie alle Kosten im Blick und treffen fundierte Entscheidungen.
+          </p>
+          <p>
+            Nutzen Sie die folgenden Hinweise als Leitfaden, um Schritt für Schritt eine
+            vollständige Kostenübersicht zu erstellen und kostspielige Überraschungen zu vermeiden.
+          </p>
+          <h2 className="text-xl font-semibold mt-6">Kostenkategorien im Überblick</h2>
+          <ul className="list-disc ml-6 space-y-2">
+            <li>
+              <strong>Materialkosten:</strong> Preise für Dämmstoffe, Fenster, Heiztechnik und
+              weiteres Bauzubehör bilden meist den größten Block.
+            </li>
+            <li>
+              <strong>Lohnkosten:</strong> Handwerker, Planer und Energieberater sollten mit
+              marktüblichen Stundensätzen kalkuliert werden.
+            </li>
+            <li>
+              <strong>Genehmigungen & Gutachten:</strong> Baugenehmigungen, Statikprüfungen oder
+              Energieausweise verursachen oft zusätzliche Gebühren.
+            </li>
+            <li>
+              <strong>Unvorhergesehenes:</strong> Für Überraschungen empfiehlt sich ein Puffer
+              von mindestens zehn Prozent der Gesamtsumme.
+            </li>
+          </ul>
+          <h2 className="text-xl font-semibold mt-6">So nutzen Sie den Budgetplaner</h2>
+          <ol className="list-decimal ml-6 space-y-2">
+            <li>
+              Projektumfang definieren und alle geplanten Maßnahmen notieren.
+            </li>
+            <li>
+              Angebote von Fachbetrieben einholen und realistische Vergleichswerte sammeln.
+            </li>
+            <li>
+              Förderprogramme recherchieren und potenzielle Zuschüsse eintragen.
+            </li>
+            <li>
+              Laufende Kosten wie Energie oder Wartung berücksichtigen, um langfristige
+              Einsparungen zu bewerten.
+            </li>
+          </ol>
+          <p>
+            Weitere hilfreiche Vorlagen wie Kostenübersichten und Finanzierungspläne finden
+            Sie im
+            <Link to="/wissenswertes/downloads" className="text-primary hover:underline">
+              {" "}Download-Center
+            </Link>
+            . Für die detaillierte Projektplanung empfiehlt sich der
+            <Link to="/projektplaner" className="text-primary hover:underline">
+              {" "}Sanierungsplaner
+            </Link>
+            .
+          </p>
+          <p>
+            Sobald Sie Ihre Daten erfasst haben, aktualisieren Sie den Plan regelmäßig.
+            So behalten Sie auch bei längeren Bauphasen jederzeit die Kontrolle über Ihr
+            Budget und können rechtzeitig gegensteuern.
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/src/pages/ProjektplanerPage.tsx
+++ b/src/pages/ProjektplanerPage.tsx
@@ -1,15 +1,62 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Link } from "react-router-dom";
 
 const ProjektplanerPage = () => {
   return (
-    <div className="container mx-auto py-10">
-      <Card>
+    <div className="container mx-auto py-10 space-y-8">
+      <Card className="animate-fade-in">
         <CardHeader>
-          <CardTitle>Projektplaner</CardTitle>
+          <CardTitle>Sanierungsplaner</CardTitle>
         </CardHeader>
-        <CardContent>
-          <p>Hier können Sie Ihr Sanierungsprojekt planen. Diese Funktion ist in Kürze verfügbar.</p>
+        <CardContent className="space-y-6 text-base leading-relaxed">
+          <p>
+            Der Sanierungsplaner begleitet Sie von der ersten Idee bis zur fertigen Umsetzung.
+            Er strukturiert alle Arbeitsschritte, ermöglicht eine realistische Zeitplanung
+            und hilft, den Überblick über Gewerke und Verantwortlichkeiten zu behalten.
+          </p>
+          <h2 className="text-xl font-semibold mt-6">Planungsphasen im Überblick</h2>
+          <ol className="list-decimal ml-6 space-y-2">
+            <li>
+              <strong>Bedarf analysieren:</strong> Prüfen Sie den Zustand Ihres Gebäudes und
+              legen Sie Prioritäten für Maßnahmen fest.
+            </li>
+            <li>
+              <strong>Budget und Finanzierung klären:</strong> Ermitteln Sie die verfügbaren
+              Mittel und berücksichtigen Sie Förderprogramme.
+            </li>
+            <li>
+              <strong>Fachbetriebe auswählen:</strong> Holen Sie Angebote ein und stimmen Sie
+              Zeitfenster mit den Handwerkern ab.
+            </li>
+            <li>
+              <strong>Ausführung überwachen:</strong> Kontrollieren Sie regelmäßig den Baufortschritt
+              und dokumentieren Sie wichtige Meilensteine.
+            </li>
+            <li>
+              <strong>Abnahme & Nachbereitung:</strong> Prüfen Sie alle Arbeiten, sichern Sie
+              Garantien und planen Sie langfristige Wartung.
+            </li>
+          </ol>
+          <h2 className="text-xl font-semibold mt-6">Tipps für eine reibungslose Umsetzung</h2>
+          <ul className="list-disc ml-6 space-y-2">
+            <li>Realistische Zeitpuffer einplanen, um Verzögerungen abzufedern.</li>
+            <li>Kommunikationswege mit allen Beteiligten klar definieren.</li>
+            <li>Änderungen schriftlich festhalten, damit Kosten und Termine nachvollziehbar bleiben.</li>
+            <li>Regelmäßig Fotos und Notizen anfertigen – das erleichtert spätere Nachweise.</li>
+          </ul>
+          <p>
+            Parallel zum Projektverlauf sollte der
+            <Link to="/budgetplan" className="text-primary hover:underline">
+              {" "}Budgetplan
+            </Link>
+            aktualisiert werden, um finanzielle Überraschungen zu vermeiden. Weitere Anleitungen
+            und Checklisten finden Sie im Bereich
+            <Link to="/wissenswertes" className="text-primary hover:underline">
+              {" "}Wissenswertes
+            </Link>
+            .
+          </p>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- replace placeholder budget page with detailed German guidance and links
- add comprehensive German project planner page with planning phases and tips
- activate Sanierungsplaner in interactive tools list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbc2403e388320baf88ae64ca05a6d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Sanierungsplaner tool is now available with a “Tool starten” link.
  - Added internal navigation links between Budgetplaner, Sanierungsplaner, and Download-Center pages.

- Documentation
  - Budgetplaner page expanded with a detailed guide: cost categories and step-by-step usage.
  - Sanierungsplaner page enriched with planning phases, practical tips, and overview content.

- Style
  - Improved layout and readability: enhanced spacing, typography, and fade-in animations.
  - Updated page titles (Projektplaner renamed to Sanierungsplaner) for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->