### PR TITLE
Replace placeholder images with real content

### DIFF
--- a/src/components/smart-home/SmartHomeCategoryCard.tsx
+++ b/src/components/smart-home/SmartHomeCategoryCard.tsx
@@ -40,15 +40,15 @@ const fetchOpenGraphImage = async (url: string): Promise<string | null> => {
 // Fallback stock photos for each category
 const getStockPhoto = (id: string): string => {
   const stockPhotos: Record<string, string> = {
-    'heizung': 'https://images.unsplash.com/photo-1621905251189-08b45d6a269e?w=400&h=300&fit=crop',
-    'beleuchtung': 'https://images.unsplash.com/photo-1558618047-3c8c76ca7d13?w=400&h=300&fit=crop',
-    'energiemanagement': 'https://images.unsplash.com/photo-1558618047-3c8c76ca7d13?w=400&h=300&fit=crop',
-    'sicherheit': 'https://images.unsplash.com/photo-1558618047-3c8c76ca7d13?w=400&h=300&fit=crop',
-    'haushalt': 'https://images.unsplash.com/photo-1558618047-3c8c76ca7d13?w=400&h=300&fit=crop',
-    'entertainment': 'https://images.unsplash.com/photo-1558618047-3c8c76ca7d13?w=400&h=300&fit=crop'
+    heizung: 'https://images.unsplash.com/photo-1581598831147-598d5b6cf1ab?auto=format&fit=crop&w=400&h=300',
+    beleuchtung: 'https://images.unsplash.com/photo-1542773667-38543c5174a1?auto=format&fit=crop&w=400&h=300',
+    energiemanagement: 'https://images.unsplash.com/photo-1581091215367-59c3aa60d5b1?auto=format&fit=crop&w=400&h=300',
+    sicherheit: 'https://images.unsplash.com/photo-1587394708532-3b3d0a76fe7e?auto=format&fit=crop&w=400&h=300',
+    haushalt: 'https://images.unsplash.com/photo-1581579184806-1a45df7ca85b?auto=format&fit=crop&w=400&h=300',
+    entertainment: 'https://images.unsplash.com/photo-1512427691650-95ce3c47ce02?auto=format&fit=crop&w=400&h=300'
   };
-  
-  return stockPhotos[id] || 'https://images.unsplash.com/photo-1558618047-3c8c76ca7d13?w=400&h=300&fit=crop';
+
+  return stockPhotos[id] || 'https://images.unsplash.com/photo-1542773667-38543c5174a1?auto=format&fit=crop&w=400&h=300';
 };
 
 const SmartHomeCategoryCard: React.FC<SmartHomeCategoryCardProps> = ({

--- a/src/data/communityData.ts
+++ b/src/data/communityData.ts
@@ -27,7 +27,7 @@ export const successStories: SuccessStory[] = [
     savings: "€1.200/Jahr",
     rating: 5,
     story: "Durch die professionelle Beratung haben wir 30% mehr Förderung erhalten als ursprünglich geplant.",
-    avatar: "/placeholder.svg",
+    avatar: "https://randomuser.me/api/portraits/men/32.jpg",
     likes: 24,
     responses: 8
   },
@@ -38,7 +38,7 @@ export const successStories: SuccessStory[] = [
     savings: "€800/Jahr",
     rating: 5,
     story: "Die Schritt-für-Schritt Anleitung war perfekt. Installation verlief problemlos.",
-    avatar: "/placeholder.svg",
+    avatar: "https://randomuser.me/api/portraits/men/83.jpg",
     likes: 18,
     responses: 12
   },
@@ -49,7 +49,7 @@ export const successStories: SuccessStory[] = [
     savings: "€1.500/Jahr",
     rating: 4,
     story: "Mit dem Sanierungsplaner konnten wir die Maßnahmen perfekt aufeinander abstimmen.",
-    avatar: "/placeholder.svg",
+    avatar: "https://randomuser.me/api/portraits/women/44.jpg",
     likes: 22,
     responses: 10
   },
@@ -60,7 +60,7 @@ export const successStories: SuccessStory[] = [
     savings: "€300/Jahr",
     rating: 4,
     story: "Die Tipps aus dem Forum haben mir viel Arbeit erspart.",
-    avatar: "/placeholder.svg",
+    avatar: "https://randomuser.me/api/portraits/women/65.jpg",
     likes: 15,
     responses: 5
   },
@@ -71,7 +71,7 @@ export const successStories: SuccessStory[] = [
     savings: "€900/Jahr",
     rating: 5,
     story: "Dank der Förderübersicht haben wir die optimale Finanzierung gefunden.",
-    avatar: "/placeholder.svg",
+    avatar: "https://randomuser.me/api/portraits/men/52.jpg",
     likes: 30,
     responses: 14
   },
@@ -82,7 +82,7 @@ export const successStories: SuccessStory[] = [
     savings: "€600/Jahr",
     rating: 5,
     story: "Mit dem KfW-Kredit 261 konnten wir unsere energetische Sanierung besonders günstig finanzieren.",
-    avatar: "/placeholder.svg",
+    avatar: "https://randomuser.me/api/portraits/men/10.jpg",
     likes: 17,
     responses: 6
   },
@@ -93,7 +93,7 @@ export const successStories: SuccessStory[] = [
     savings: "€400/Jahr",
     rating: 4,
     story: "Die BAFA-Förderung half mir, die Kosten für eine effiziente Wärmepumpe deutlich zu senken.",
-    avatar: "/placeholder.svg",
+    avatar: "https://randomuser.me/api/portraits/men/21.jpg",
     likes: 12,
     responses: 4
   },
@@ -104,7 +104,7 @@ export const successStories: SuccessStory[] = [
     savings: "€2.000/Jahr",
     rating: 5,
     story: "Ein Sanierungsfahrplan vom Energieberater war der Schlüssel zu maximaler Förderung und geringeren Energiekosten.",
-    avatar: "/placeholder.svg",
+    avatar: "https://randomuser.me/api/portraits/women/12.jpg",
     likes: 35,
     responses: 16
   }

--- a/src/pages/SmartHomePage.tsx
+++ b/src/pages/SmartHomePage.tsx
@@ -36,7 +36,7 @@ const smartHomeCategories = [
     title: "Smarte Heizungssteuerung",
     description:
       "Intelligente Thermostate passen die Raumtemperatur automatisch an Ihren Tagesablauf und die Wettervorhersage an. So heizen Sie nur, wenn es wirklich nötig ist, und können Ihre Heizkosten um bis zu 20% senken.",
-    image: "/placeholder.svg?id=photo-1581091226825-a6a2a5aee158",
+    image: "https://images.unsplash.com/photo-1581598831147-598d5b6cf1ab?auto=format&fit=crop&w=400&h=300",
     alt: "Frau steuert Heizung per Smartphone-App",
     product: {
       name: "tado° Smartes Heizkörper-Thermostat",
@@ -50,7 +50,7 @@ const smartHomeCategories = [
     title: "Intelligente Beleuchtung",
     description:
       "Dimmbares Licht, Zeitpläne und Anwesenheitserkennung helfen, Strom zu sparen und Komfort zu erhöhen. Smarte LEDs schalten sich automatisch aus, wenn niemand da ist.",
-    image: "/placeholder.svg?id=photo-1581090464777-f3220bbe1b8b",
+    image: "https://images.unsplash.com/photo-1542773667-38543c5174a1?auto=format&fit=crop&w=400&h=300",
     alt: "Hand mit leuchtender Glühbirne, Symbol für smarte Beleuchtung",
     product: {
       name: "Philips Hue White Ambiance Starter-Set",
@@ -64,7 +64,7 @@ const smartHomeCategories = [
     title: "Energiemanagement & Steckdosen",
     description:
       "Finden Sie mit smarten Steckdosen die größten Stromverbraucher und schalten Sie Geräte per Zeitplan ganz aus. Perfekt zum Standby-Sparen.",
-    image: "/placeholder.svg?id=photo-1488590528505-98d2b5aba04b",
+    image: "https://images.unsplash.com/photo-1581091215367-59c3aa60d5b1?auto=format&fit=crop&w=400&h=300",
     alt: "Moderne smarte Steckdose in einer Wand",
     product: {
       name: "AVM FRITZ!DECT 200",
@@ -78,7 +78,7 @@ const smartHomeCategories = [
     title: "Smarte Sicherheit & Überwachung",
     description:
       "Mit intelligenten Kameras, Bewegungsmeldern und Tür-/Fenstersensoren behalten Sie Ihr Zuhause immer im Blick – auch unterwegs.",
-    image: "/placeholder.svg?id=photo-1618160702438-9b02ab6515c9",
+    image: "https://images.unsplash.com/photo-1587394708532-3b3d0a76fe7e?auto=format&fit=crop&w=400&h=300",
     alt: "Cam mit Sicht auf einen Eingangsbereich",
     product: {
       name: "eufy Security SoloCam S220",
@@ -91,7 +91,7 @@ const smartHomeCategories = [
     title: "Smarte Haushaltsgeräte",
     description:
       "Automatisieren Sie Haushaltsaufgaben! Intelligente Saugroboter, Waschmaschinen & Co. sparen Zeit und oft auch Strom.",
-    image: "/placeholder.svg?id=photo-1582562124811-c09040d0a901",
+    image: "https://images.unsplash.com/photo-1581579184806-1a45df7ca85b?auto=format&fit=crop&w=400&h=300",
     alt: "Haushalt: smarter Saugroboter im Wohnzimmer",
     product: {
       name: "Roborock S8 Saugroboter",
@@ -104,7 +104,7 @@ const smartHomeCategories = [
     title: "Smart Entertainment & Multiroom",
     description:
       "Steuern Sie Musik, TV und Lautsprecher zentral. Smarte Lösungen sorgen für perfekten Sound & Komfort – auf Sprachbefehl oder per App.",
-    image: "/placeholder.svg?id=photo-1721322800607-8c38375eef04",
+    image: "https://images.unsplash.com/photo-1512427691650-95ce3c47ce02?auto=format&fit=crop&w=400&h=300",
     alt: "Modernes Wohnzimmer mit vernetztem Soundsystem",
     product: {
       name: "Sonos One (Gen 2)",


### PR DESCRIPTION
## Summary
- replace placeholder avatars in community success stories with actual user images
- swap smart home category placeholders for unsplash photos and update stock fallbacks

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bbf2fffa1c8320b38566166e47b876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Upgraded Smart Home category images to high-quality, consistently cropped photos for a more polished look.
  * Improved default/fallback image to match new visual style.
  * Refreshed community success story avatars with realistic profile photos.
  * Ensured visual consistency across category cards and listings.

* **Chores**
  * Replaced placeholder assets with externally hosted images to improve presentation without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->