### PR TITLE
Integrate sunshine API into solar calculator

### DIFF
--- a/src/utils/fetchSunshineData.ts
+++ b/src/utils/fetchSunshineData.ts
@@ -1,0 +1,36 @@
+export interface SunshineData {
+  sunshineHours: number; // durchschnittliche Stunden pro Tag
+  sunnyDays: number; // Anzahl Tage mit >= 4h Sonne
+  regionalFactor: number; // Faktor für Solarkalkulation
+}
+
+export async function fetchSunshineData(plz: string): Promise<SunshineData | null> {
+  try {
+    const geoRes = await fetch(`https://geocoding-api.open-meteo.com/v1/search?name=${plz}&count=1&language=de`);
+    const geoJson = await geoRes.json();
+    const geo = geoJson.results?.[0];
+    if (!geo) return null;
+
+    const weatherRes = await fetch(
+      `https://api.open-meteo.com/v1/forecast?latitude=${geo.latitude}&longitude=${geo.longitude}&daily=sunshine_duration&timezone=Europe/Berlin&past_days=7&forecast_days=0`
+    );
+    const weatherJson = await weatherRes.json();
+    const durations: number[] = weatherJson.daily?.sunshine_duration || [];
+    if (!durations.length) return null;
+
+    const hoursArray = durations.map(sec => sec / 3600);
+    const sunnyDays = hoursArray.filter(h => h >= 4).length;
+    const avgSunshineHours = hoursArray.reduce((a, b) => a + b, 0) / hoursArray.length;
+    const annualSunshineHours = avgSunshineHours * 365;
+    const regionalFactor = annualSunshineHours / 1600; // 1600h als Basis
+
+    return {
+      sunshineHours: avgSunshineHours,
+      sunnyDays,
+      regionalFactor,
+    };
+  } catch (err) {
+    console.error('Failed to fetch sunshine data', err);
+    return null;
+  }
+}

--- a/src/utils/solarCalculations.ts
+++ b/src/utils/solarCalculations.ts
@@ -153,17 +153,22 @@ const calculateNeigungsFaktor = (neigung: number): number => {
 // Monatliche Ertragskurve (Deutschland)
 const MONTHLY_FACTORS = [0.4, 0.6, 0.9, 1.2, 1.4, 1.5, 1.5, 1.3, 1.1, 0.8, 0.5, 0.3];
 
-export const getConfiguration = (inputs: SolarInputs): SolarConfiguration => {
+export const getConfiguration = (
+  inputs: SolarInputs,
+  regionalFaktorOverride?: number
+): SolarConfiguration => {
   const plzPrefix = inputs.plz.substring(0, 2);
   const regionalData = REGIONAL_DATA[plzPrefix] || REGIONAL_DATA['50']; // Fallback auf NRW
-  
+
   return {
-    regionalFaktor: regionalData.faktor,
+    regionalFaktor: regionalFaktorOverride ?? regionalData.faktor,
     verschattungsFaktor: CONSTANTS.VERSCHATTUNG_FAKTOREN[inputs.verschattung],
     neigungsFaktor: calculateNeigungsFaktor(inputs.dachneigung),
     modulWirkungsgrad: CONSTANTS.MODUL_WIRKUNGSGRAD[inputs.modultyp],
     eigenverbrauchOhneSpeicher: CONSTANTS.EIGENVERBRAUCH_OHNE_SPEICHER,
-    eigenverbrauchMitSpeicher: inputs.mitSpeicher ? CONSTANTS.EIGENVERBRAUCH_MIT_SPEICHER : CONSTANTS.EIGENVERBRAUCH_OHNE_SPEICHER,
+    eigenverbrauchMitSpeicher: inputs.mitSpeicher
+      ? CONSTANTS.EIGENVERBRAUCH_MIT_SPEICHER
+      : CONSTANTS.EIGENVERBRAUCH_OHNE_SPEICHER,
   };
 };
 
@@ -190,8 +195,11 @@ export const calculateCosts = (inputs: SolarInputs, anlageGroesse: number): Sola
   };
 };
 
-export const calculateSolarResults = (inputs: SolarInputs): SolarResults => {
-  const config = getConfiguration(inputs);
+export const calculateSolarResults = (
+  inputs: SolarInputs,
+  regionalFaktorOverride?: number
+): SolarResults => {
+  const config = getConfiguration(inputs, regionalFaktorOverride);
   const anlageGroesse = parseFloat((inputs.dachflaeche / CONSTANTS.M2_PER_KWP).toFixed(2));
   
   // Jahresertrag berechnen


### PR DESCRIPTION
## Summary
- fetch sunshine duration via Open-Meteo by postal code
- adjust solar calculations with dynamic regional factor
- show last-week sunshine stats in solar calculator UI

## Testing
- `npm run lint` (fails: Unexpected any & require warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc05f4fd408320932ecdba77388fb8