### PR TITLE
Add topics overview page with glossary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Index from "./pages/Index";
 import Blog from "./pages/Blog";
 import BlogPost from "./pages/BlogPost";
 import CategoryPage from "./pages/CategoryPage";
+import TopicsPage from "./pages/TopicsPage";
 import FoerdermittelPage from "./pages/FoerdermittelPage";
 import DaemmungsrechnerPage from "./pages/DaemmungsrechnerPage";
 import DaemmungIsolierungPage from "./pages/DaemmungIsolierungPage";
@@ -67,6 +68,7 @@ function App() {
                   <Route path="/" element={<Index />} />
                   <Route path="/blog" element={<Blog />} />
                   <Route path="/blog/:slug" element={<BlogPost />} />
+                  <Route path="/themen" element={<TopicsPage />} />
                   <Route path="/themen/:categorySlug" element={<CategoryPage />} />
                   <Route path="/foerdermittel" element={<FoerdermittelPage />} />
                   <Route path="/daemmungsrechner" element={<DaemmungsrechnerPage />} />

--- a/src/data/glossary.ts
+++ b/src/data/glossary.ts
@@ -1,0 +1,34 @@
+export type GlossaryItem = {
+  term: string;
+  definition: string;
+};
+
+export const glossary: GlossaryItem[] = [
+  {
+    term: "BEG",
+    definition:
+      "Bundesf\u00f6rderung f\u00fcr effiziente Geb\u00e4ude \u2013 zentrales deutsches F\u00f6rderprogramm f\u00fcr Sanierungen.",
+  },
+  {
+    term: "KfW",
+    definition:
+      "Kreditanstalt f\u00fcr Wiederaufbau, bietet zinsg\u00fcnstige Kredite und Zusch\u00fcsse f\u00fcr Effizienzma\u00dfnahmen.",
+  },
+  {
+    term: "WDVS",
+    definition:
+      "W\u00e4rmed\u00e4mmverbundsystem \u2013 au\u00dfen aufgebrachte D\u00e4mmung zur Verbesserung der Energieeffizienz von Geb\u00e4uden.",
+  },
+  {
+    term: "Photovoltaik",
+    definition:
+      "Technik zur Stromerzeugung aus Sonnenlicht mittels Solarzellen auf Dachfl\u00e4chen oder Freianlagen.",
+  },
+  {
+    term: "Smart Meter",
+    definition:
+      "Intelligenter Stromz\u00e4hler, der den Energieverbrauch digital erfasst und an den Versorger \u00fcbermittelt.",
+  },
+];
+
+export default glossary;

--- a/src/pages/TopicsPage.tsx
+++ b/src/pages/TopicsPage.tsx
@@ -1,0 +1,48 @@
+import { Link } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
+import { siteConfig } from '@/config/site.config';
+import { glossary } from '@/data/glossary';
+
+const TopicsPage = () => {
+  return (
+    <div className="container max-w-5xl mx-auto px-4 py-12">
+      <Helmet>
+        <title>Themen\u00fcbersicht \u2013 Sanieren & Sparen</title>
+        <meta
+          name="description"
+          content="\u00dcbersicht \u00fcber alle Themen unseres Blogs plus Glossar wichtiger Begriffe."
+        />
+      </Helmet>
+
+      <h1 className="text-3xl font-bold mb-6">Themen\u00fcbersicht</h1>
+      <p className="text-gray-600 mb-8">
+        Entdecken Sie unsere wichtigsten Inhalte rund um energieeffizientes Sanieren und Modernisieren.
+      </p>
+
+      <div className="grid gap-6 sm:grid-cols-2">
+        {siteConfig.contentTopics.map((topic) => (
+          <Link
+            key={topic.id}
+            to={topic.seoUrl}
+            className="block p-6 border rounded-lg hover:shadow-md transition-shadow"
+          >
+            <h2 className="text-xl font-semibold mb-2">{topic.name}</h2>
+            <p className="text-gray-600 text-sm">{topic.description}</p>
+          </Link>
+        ))}
+      </div>
+
+      <h2 className="text-2xl font-bold mt-16 mb-4">Glossar</h2>
+      <dl className="space-y-4">
+        {glossary.map((item) => (
+          <div key={item.term}>
+            <dt className="font-semibold">{item.term}</dt>
+            <dd className="text-gray-600 text-sm">{item.definition}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+};
+
+export default TopicsPage;


### PR DESCRIPTION
## Summary
- Add dedicated topics overview page to resolve `/themen` 404
- Introduce glossary definitions file
- Register new page route

## Testing
- `npm run lint` *(fails: Unexpected any and other existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc15576c00832099f2f9209ea76dbb