### PR TITLE
feat: add energie-check page with federal energy data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,9 @@ import Blog from "./pages/Blog";
 import BlogPost from "./pages/BlogPost";
 import CategoryPage from "./pages/CategoryPage";
 import FoerdermittelPage from "./pages/FoerdermittelPage";
+import FoerderrechnerPage from "./pages/FoerderrechnerPage";
+import EnergieCheckPage from "./pages/EnergieCheckPage";
+import ROIRechnerPage from "./pages/ROIRechnerPage";
 import DaemmungsrechnerPage from "./pages/DaemmungsrechnerPage";
 import DaemmungIsolierungPage from "./pages/DaemmungIsolierungPage";
 import HeizkostenrechnerPage from "./pages/HeizkostenrechnerPage";
@@ -69,6 +72,9 @@ function App() {
                   <Route path="/blog/:slug" element={<BlogPost />} />
                   <Route path="/themen/:categorySlug" element={<CategoryPage />} />
                   <Route path="/foerdermittel" element={<FoerdermittelPage />} />
+                  <Route path="/foerderrechner" element={<FoerderrechnerPage />} />
+                  <Route path="/energie-check" element={<EnergieCheckPage />} />
+                  <Route path="/roi-rechner" element={<ROIRechnerPage />} />
                   <Route path="/daemmungsrechner" element={<DaemmungsrechnerPage />} />
                   <Route path="/daemmung-isolierung" element={<DaemmungIsolierungPage />} />
                   <Route path="/heizkostenrechner" element={<HeizkostenrechnerPage />} />

--- a/src/components/wissenswertes/InteractiveTools.tsx
+++ b/src/components/wissenswertes/InteractiveTools.tsx
@@ -16,21 +16,21 @@ const InteractiveTools = () => {
       title: "Förderrechner",
       description: "Berechnen Sie alle verfügbaren Fördermittel für Ihr Projekt",
       icon: Calculator,
-      comingSoon: true,
+      comingSoon: false,
       path: "/foerderrechner"
     },
     {
       title: "Energie-Check",
       description: "Schnelle Bewertung Ihres Sanierungsbedarfs",
       icon: Zap,
-      comingSoon: true,
+      comingSoon: false,
       path: "/energie-check"
     },
     {
       title: "ROI-Rechner",
       description: "Amortisationszeiten für verschiedene Sanierungsmaßnahmen",
       icon: TrendingUp,
-      comingSoon: true,
+      comingSoon: false,
       path: "/roi-rechner"
     },
     {

--- a/src/integrations/electricityPrice.ts
+++ b/src/integrations/electricityPrice.ts
@@ -1,0 +1,28 @@
+export interface ElectricityPrice {
+  date: string;
+  eurPerKwh: number;
+}
+
+interface EnergyChartsResponse {
+  price: number[];
+  unix_seconds: number[];
+}
+
+export async function fetchLatestElectricityPrice(): Promise<ElectricityPrice> {
+  const today = new Date().toISOString().split('T')[0];
+  const url = `https://api.energy-charts.info/price?start=${today}&end=${today}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Failed to fetch electricity price');
+  }
+  const data: EnergyChartsResponse = await res.json();
+  const { price, unix_seconds } = data;
+  if (!price?.length || !unix_seconds?.length) {
+    throw new Error('Malformed price data');
+  }
+  const latestIndex = price.length - 1;
+  return {
+    date: new Date(unix_seconds[latestIndex] * 1000).toISOString(),
+    eurPerKwh: price[latestIndex] / 1000
+  };
+}

--- a/src/integrations/energyConsumption.ts
+++ b/src/integrations/energyConsumption.ts
@@ -1,0 +1,27 @@
+export interface HouseholdEnergyConsumption {
+  year: string;
+  valueTJ: number;
+}
+
+export async function fetchHouseholdEnergyConsumption(): Promise<HouseholdEnergyConsumption> {
+  const url = 'https://www-genesis.destatis.de/genesis-old/downloads/00/tables/85121-0001_00.csv';
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Failed to fetch energy consumption data');
+  }
+  const text = await res.text();
+  const lines = text.split('\n');
+  const yearLine = lines.find((line) => line.startsWith(';;'));
+  const dataLine = lines.find((line) => line.startsWith('PRIVATHH'));
+  if (!yearLine || !dataLine) {
+    throw new Error('Unexpected CSV format');
+  }
+  const years = yearLine.split(';').slice(2).map((y) => y.trim());
+  const values = dataLine
+    .split(';')
+    .slice(2)
+    .map((v) => Number(v.replace(',', '.')));
+  const year = years[years.length - 1];
+  const valueTJ = values[values.length - 1];
+  return { year, valueTJ };
+}

--- a/src/integrations/govdata.ts
+++ b/src/integrations/govdata.ts
@@ -1,0 +1,25 @@
+export interface FederalProgram {
+  title: string;
+  description?: string;
+  url: string;
+}
+
+interface GovDataPackage {
+  title: string;
+  notes?: string;
+  url?: string;
+  resources?: { url: string }[];
+}
+
+export async function getFederalPrograms(): Promise<FederalProgram[]> {
+  const response = await fetch(
+    'https://www.govdata.de/ckan/api/3/action/package_search?q=f%C3%B6rderprogramm%20bund'
+  );
+  const json = await response.json();
+  const packages: GovDataPackage[] = json.result?.results ?? [];
+  return packages.map((pkg) => ({
+    title: pkg.title,
+    description: pkg.notes,
+    url: pkg.url ?? pkg.resources?.[0]?.url ?? '#'
+  }));
+}

--- a/src/pages/EnergieCheckPage.tsx
+++ b/src/pages/EnergieCheckPage.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
+import { fetchHouseholdEnergyConsumption, HouseholdEnergyConsumption } from '@/integrations/energyConsumption';
+
+interface Question {
+  id: number;
+  text: string;
+}
+
+const questions: Question[] = [
+  { id: 1, text: 'Ist Ihr Gebäude gut gedämmt?' },
+  { id: 2, text: 'Nutzen Sie erneuerbare Energien?' },
+  { id: 3, text: 'Sind Ihre Fenster modern und isolierend?' }
+];
+
+type AnswerMap = Record<number, string>;
+
+const EnergieCheckPage = () => {
+  const [answers, setAnswers] = useState<AnswerMap>({});
+  const [consumption, setConsumption] = useState<HouseholdEnergyConsumption | null>(null);
+
+  useEffect(() => {
+    fetchHouseholdEnergyConsumption().then(setConsumption).catch(() => {
+      /* ignore errors for now */
+    });
+  }, []);
+
+  const handleChange = (id: number, value: string) => {
+    setAnswers((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const positive = Object.values(answers).filter((v) => v === 'yes').length;
+  const message = positive >= 2 ? 'Gute Ausgangslage für Ihr Zuhause' : 'Es besteht Verbesserungsbedarf';
+
+  return (
+    <div className="container py-10 space-y-6">
+      <h1 className="text-3xl font-bold mb-4">Energie-Check</h1>
+      <p className="text-muted-foreground mb-6">
+        Beantworten Sie die folgenden Fragen für eine erste Einschätzung.
+      </p>
+      <div className="space-y-4">
+        {questions.map((q) => (
+          <Card key={q.id}>
+            <CardHeader>
+              <CardTitle className="text-lg">{q.text}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <RadioGroup onValueChange={(val) => handleChange(q.id, val)}>
+                <div className="flex items-center space-x-2 mb-2">
+                  <RadioGroupItem value="yes" id={`yes-${q.id}`} />
+                  <Label htmlFor={`yes-${q.id}`}>Ja</Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="no" id={`no-${q.id}`} />
+                  <Label htmlFor={`no-${q.id}`}>Nein</Label>
+                </div>
+              </RadioGroup>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      {Object.keys(answers).length === questions.length && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Ergebnis</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p>{message}</p>
+          </CardContent>
+        </Card>
+      )}
+      {consumption && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Bundesweite Referenz</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p>
+              Energieverbrauch privater Haushalte in Deutschland ({consumption.year}):{' '}
+              {consumption.valueTJ.toLocaleString()} TJ
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+};
+
+export default EnergieCheckPage;

--- a/src/pages/FoerderrechnerPage.tsx
+++ b/src/pages/FoerderrechnerPage.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import BreadcrumbNavigation from '@/components/ui/breadcrumb-navigation';
+import { getFederalPrograms, FederalProgram } from '@/integrations/govdata';
+
+const FoerderrechnerPage = () => {
+  const [programs, setPrograms] = useState<FederalProgram[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getFederalPrograms()
+      .then(setPrograms)
+      .catch((err) => setError(err.message));
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <main>
+        <div className="container max-w-3xl mx-auto px-4 py-8">
+          <BreadcrumbNavigation
+            items={[
+              { label: 'Ratgeber', href: '/wissenswertes' },
+              { label: 'Rechner & Tools', href: '/wissenswertes/tools' },
+              { label: 'Förderrechner' }
+            ]}
+            className="mb-6"
+          />
+          <h1 className="text-3xl font-bold text-gray-900 mb-4">Förderrechner</h1>
+          <p className="text-gray-600 text-lg mb-8">
+            Aktuelle Bundesförderprogramme aus dem offenen GovData-Portal.
+          </p>
+          {error && <p className="text-red-500">{error}</p>}
+          <ul className="space-y-4">
+            {programs.map((program, index) => (
+              <li key={index} className="p-4 border rounded">
+                <a
+                  href={program.url}
+                  className="font-semibold text-blue-700 hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {program.title}
+                </a>
+                {program.description && (
+                  <p className="text-sm text-gray-600">{program.description}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default FoerderrechnerPage;

--- a/src/pages/ROIRechnerPage.tsx
+++ b/src/pages/ROIRechnerPage.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import BreadcrumbNavigation from '@/components/ui/breadcrumb-navigation';
+import { fetchLatestElectricityPrice } from '@/integrations/electricityPrice';
+
+const ROIRechnerPage = () => {
+  const [investment, setInvestment] = useState('');
+  const [savings, setSavings] = useState('');
+  const [price, setPrice] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchLatestElectricityPrice()
+      .then((data) => setPrice(data.eurPerKwh.toFixed(4)))
+      .catch((err) => setError(err.message));
+  }, []);
+
+  const investmentNum = parseFloat(investment);
+  const savingsNum = parseFloat(savings);
+  const priceNum = parseFloat(price);
+  const canCalc = investmentNum > 0 && savingsNum > 0 && priceNum > 0;
+  const payback = canCalc ? investmentNum / (savingsNum * priceNum) : null;
+  const roiPercent = canCalc ? (savingsNum * priceNum) / investmentNum * 100 : null;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <main>
+        <div className="container max-w-3xl mx-auto px-4 py-8">
+          <BreadcrumbNavigation
+            items={[
+              { label: 'Ratgeber', href: '/wissenswertes' },
+              { label: 'Rechner & Tools', href: '/wissenswertes/tools' },
+              { label: 'ROI-Rechner' }
+            ]}
+            className="mb-6"
+          />
+          <h1 className="text-3xl font-bold text-gray-900 mb-4">ROI-Rechner</h1>
+          <p className="text-gray-600 text-lg mb-8">
+            Berechnen Sie die Amortisationszeit Ihrer Investition.
+          </p>
+          {error && <p className="text-red-500">{error}</p>}
+          <div className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Eingaben</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <label className="block mb-1 text-sm font-medium">Investitionskosten (EUR)</label>
+                  <Input
+                    type="number"
+                    value={investment}
+                    onChange={(e) => setInvestment(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <label className="block mb-1 text-sm font-medium">Jährliche Energieeinsparung (kWh)</label>
+                  <Input
+                    type="number"
+                    value={savings}
+                    onChange={(e) => setSavings(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <label className="block mb-1 text-sm font-medium">Energiepreis (EUR/kWh)</label>
+                  <Input
+                    type="number"
+                    value={price}
+                    onChange={(e) => setPrice(e.target.value)}
+                  />
+                </div>
+              </CardContent>
+            </Card>
+            {canCalc && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Ergebnis</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p>Amortisationszeit: {payback?.toFixed(1)} Jahre</p>
+                  <p>Jährliche Rendite: {roiPercent?.toFixed(1)}%</p>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default ROIRechnerPage;


### PR DESCRIPTION
## Summary
- add Energie-Check page with simple questionnaire and federal household energy reference
- fetch household energy consumption from Destatis CSV via new integration
- expose Energie-Check in interactive tools and routing
- introduce GovData integration to list federal funding programs and provide a Förderrechner page
- add ROI calculator that uses Bundesnetzagentur price data to estimate payback period

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c6c835178483208383675b10c651d8